### PR TITLE
feat: add option of using local Eik asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ npm i @podium/eik-podlet-server-extension
   // ...
 }
 ```
+
+## Debug `podlet build`
+
+If you want to use the local files also outside development, for local debugging, run:
+
+```
+podlet build
+EIK_DEVELOPMENT=true podlet start
+```

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const join = (...segments) => {
  *
  * @param {Object} options - The options object.
  * @param {string} options.cwd - The current working directory.
- * @param {boolean} options.development - Whether the server is running in development mode.
+ * @param {boolean} [options.development] - Whether the server is running in development mode.
  * @returns {Promise<Object>} The configuration object.
  * @throws {Error} If the eik.json file cannot be read.
  */
@@ -27,11 +27,16 @@ export const config = async ({ cwd, development }) => {
       })
     );
 
+    let useLocalFiles = development;
+    if (process.env.EIK_DEVELOPMENT === "true") {
+      useLocalFiles = true;
+    }
+
     return {
       assets: {
         base: {
           format: String,
-          default: development
+          default: useLocalFiles
             ? "/static"
             : new URL(join("pkg", eik.name, eik.version), eik.server).href,
         },


### PR DESCRIPTION
Sometimes useful to debug issues with the Eik asset without publishing.

`DEVELOPMENT=true npm start` gives me scripts pointing to `/_/dynamic/` (which has its own build function separate from the `build` command), not `/static`, hence the separate variable.

I'm open to solve this differently. My goal is to be able to run `podlet build`, and test that build on localhost in a "non-development mode", before publishing to Eik.
